### PR TITLE
feat: use laptop hostname in instance names and display instance info

### DIFF
--- a/deploy-k8s-cluster.sh
+++ b/deploy-k8s-cluster.sh
@@ -33,13 +33,42 @@ deploy_cluster() {
     ansible-playbook -i "$INVENTORY_FILE" kubernetes-single-node.yaml
 
     echo "Deployment complete!"
-    echo "Check the instance details file for SSH access information." 
 
     echo "Deploying LLM-D..."
     ansible-playbook -i "$INVENTORY_FILE" llm-d-deploy.yaml
 
     echo "Testing LLM-D..."
     ansible-playbook -i "$INVENTORY_FILE" llm-d-test.yaml
+    
+    echo ""
+    echo "=== Instance Information ==="
+    
+    # Find the most recent instance details file
+    DETAILS_FILE=$(ls -rt instance-*-details.txt | tail -1)
+    
+    if [ -n "$DETAILS_FILE" ]; then
+        # Extract key information from the details file
+        INSTANCE_ID=$(grep "Instance ID:" "$DETAILS_FILE" | cut -d' ' -f3)
+        INSTANCE_NAME=$(grep "Instance Name:" "$DETAILS_FILE" | cut -d' ' -f3)
+        PUBLIC_IP=$(grep "Public IP:" "$DETAILS_FILE" | cut -d' ' -f3)
+        PRIVATE_IP=$(grep "Private IP:" "$DETAILS_FILE" | cut -d' ' -f3)
+        INSTANCE_TYPE=$(grep "Instance Type:" "$DETAILS_FILE" | cut -d' ' -f3)
+        SSH_COMMAND=$(grep "ssh -i" "$DETAILS_FILE")
+        
+        echo "Instance ID: $INSTANCE_ID"
+        echo "Instance Name: $INSTANCE_NAME"
+        echo "Instance Type: $INSTANCE_TYPE"
+        echo "Public IP: $PUBLIC_IP"
+        echo "Private IP: $PRIVATE_IP"
+        echo ""
+        echo "SSH Access:"
+        echo "$SSH_COMMAND"
+        echo ""
+        echo "Full details saved to: $DETAILS_FILE"
+    else
+        echo "Warning: Could not find instance details file"
+        echo "Check the instance details file for SSH access information."
+    fi 
 }
 
 cleanup_instances() {

--- a/launch-instance.yaml
+++ b/launch-instance.yaml
@@ -10,7 +10,7 @@
     key_pair: router-team-us-east2
     security_group_id: sg-0704e6bcaa5e655b1  # k8s security group
     root_volume_size: 500  # GB
-    instance_name: "GPU-Instance-{{ ansible_date_time.epoch }}"
+    instance_name: "{{ ansible_hostname }}-{{ ansible_date_time.epoch }}"
     
   tasks:
     - name: Ensure boto3 and botocore are installed


### PR DESCRIPTION
## Summary
Improves instance naming and deployment feedback by using the operator's laptop hostname instead of a generic "GPU-Instance" prefix and displaying comprehensive instance information upon deployment completion.

## Changes Made
- **Instance Naming**: Replace `GPU-Instance` with `ansible_hostname` in instance naming to make instances more identifiable by operator
- **Deployment Summary**: Add comprehensive instance information display at deployment completion including:
  - Instance ID and Name
  - Instance Type and IPs (public/private)
  - Ready-to-use SSH command
  - Details file location

## Benefits
- Better instance identification and management when multiple operators are using the provisioner
- Immediate access to connection information without needing to check separate files
- Improved user experience with clear deployment completion feedback

## Testing
- ✅ Verified instance naming works with laptop hostname
- ✅ Confirmed deployment summary displays all relevant information
- ✅ SSH command generation works correctly