### PR TITLE
Make the deploy script work for different regions

### DIFF
--- a/cleanup-instance.yaml
+++ b/cleanup-instance.yaml
@@ -4,7 +4,7 @@
   connection: local
   gather_facts: true
   vars:
-    aws_region: us-east-2
+    # No hardcoded region - will detect from instance details files
     
   tasks:
     - name: Ensure boto3 and botocore are installed
@@ -20,6 +20,26 @@
         paths: "."
         patterns: "gpu-inventory-*.ini"
       register: inventory_files
+
+    - name: Find instance details files
+      find:
+        paths: "."
+        patterns: "instance-*-details.txt"
+      register: details_files
+
+    - name: Extract instance info from details files
+      shell: |
+        for file in instance-*-details.txt; do
+          if [ -f "$file" ]; then
+            instance_id=$(grep "^Instance ID:" "$file" | cut -d' ' -f3)
+            region=$(grep "^Region:" "$file" | cut -d' ' -f2)
+            if [ -n "$instance_id" ] && [ -n "$region" ]; then
+              echo "${instance_id}:${region}"
+            fi
+          fi
+        done
+      register: details_instance_info
+      when: details_files.files | length > 0
 
     - name: Extract instance IDs from inventory files
       shell: |
@@ -43,33 +63,60 @@
       register: extracted_instance_ids
       when: inventory_files.files | length > 0
 
-    - name: Set instance IDs variable
+    - name: Build instance region mapping (prioritize details files)
       set_fact:
-        instance_ids: "{{ extracted_instance_ids.stdout_lines }}"
-      when: inventory_files.files | length > 0 and extracted_instance_ids.stdout_lines | length > 0
+        instances_by_region: >-
+          {%- set result = {} -%}
+          {%- set processed_instances = [] -%}
+          
+          {# First, process instances from details files (they have accurate region info) #}
+          {%- for item in details_instance_info.stdout_lines | default([]) -%}
+            {%- set parts = item.split(':') -%}
+            {%- set instance_id = parts[0] -%}
+            {%- set region = parts[1] if parts|length > 1 else 'us-east-2' -%}
+            {%- if region not in result -%}
+              {%- set _ = result.update({region: []}) -%}
+            {%- endif -%}
+            {%- if instance_id not in result[region] -%}
+              {%- set _ = result[region].append(instance_id) -%}
+              {%- set _ = processed_instances.append(instance_id) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          
+          {# Then, process instances from inventory files only if not already processed #}
+          {%- for instance_id in extracted_instance_ids.stdout_lines | default([]) -%}
+            {%- if instance_id not in processed_instances -%}
+              {%- set region = 'us-east-2' -%}
+              {%- if region not in result -%}
+                {%- set _ = result.update({region: []}) -%}
+              {%- endif -%}
+              {%- if instance_id not in result[region] -%}
+                {%- set _ = result[region].append(instance_id) -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+          
+          {{ result }}
+      when: (details_instance_info.stdout_lines | default([]) | length > 0) or (extracted_instance_ids.stdout_lines | default([]) | length > 0)
 
-    - name: Display found instance IDs
+    - name: Display instances grouped by region
       debug:
-        msg: "Found instance IDs from inventory files: {{ instance_ids }}"
-      when: instance_ids is defined and instance_ids | length > 0
+        msg: "Found instances by region: {{ instances_by_region }}"
+      when: instances_by_region is defined
 
-    - name: Get instance information
+    - name: Get instance information for each region
       amazon.aws.ec2_instance_info:
-        region: "{{ aws_region }}"
-        instance_ids: "{{ instance_ids }}"
-      register: instances_info
-      when: instance_ids is defined and instance_ids | length > 0
-
-    - name: Set instances to delete
-      set_fact:
-        instances_to_delete: "{{ instances_info.instances }}"
-      when: instances_info is defined and instances_info.instances is defined
+        region: "{{ item.key }}"
+        instance_ids: "{{ item.value }}"
+      register: all_instances_info
+      loop: "{{ instances_by_region | dict2items }}"
+      when: instances_by_region is defined
 
     - name: Display instances that will be deleted
       debug:
         msg: |
-          The following instances will be DELETED:
-          {% for instance in instances_to_delete %}
+          The following instances will be DELETED in region {{ item.item.key }}:
+          {% for instance in item.instances %}
           - Instance ID: {{ instance.instance_id }}
             Name: {{ instance.tags.Name | default('N/A') }}
             Type: {{ instance.instance_type }}
@@ -78,29 +125,30 @@
             Private IP: {{ instance.private_ip_address }}
             Launch Time: {{ instance.launch_time }}
           {% endfor %}
-      when: instances_to_delete is defined and instances_to_delete | length > 0
+      loop: "{{ all_instances_info.results }}"
+      when: all_instances_info is defined and all_instances_info.results is defined
 
     - name: Confirm no instances found
       debug:
-        msg: "No inventory files found. Nothing to cleanup."
-      when: inventory_files.files | length == 0
+        msg: "No inventory or details files found. Nothing to cleanup."
+      when: instances_by_region is not defined or instances_by_region | length == 0
 
-    - name: Terminate instances
+    - name: Terminate instances by region
       amazon.aws.ec2_instance:
-        region: "{{ aws_region }}"
+        region: "{{ item.0.item.key }}"
         instance_ids:
-          - "{{ item.instance_id }}"
+          - "{{ item.1.instance_id }}"
         state: terminated
         wait: true
         wait_timeout: 30
-      loop: "{{ instances_to_delete }}"
+      loop: "{{ all_instances_info.results | subelements('instances') }}"
       register: termination_results
-      when: instances_to_delete is defined and instances_to_delete | length > 0
+      when: all_instances_info is defined and all_instances_info.results is defined
 
     - name: Display termination results
       debug:
         msg: |
-          Instance {{ item.item.instance_id }} ({{ item.item.tags.Name | default('N/A') }}) 
+          Instance {{ item.item.1.instance_id }} ({{ item.item.1.tags.Name | default('N/A') }}) in region {{ item.item.0.item.key }}
           termination status: {{ item.changed | ternary('terminated', 'unchanged') }}
       loop: "{{ termination_results.results }}"
       when: termination_results is defined and termination_results.results is defined
@@ -110,14 +158,22 @@
         path: "{{ item.path }}"
         state: absent
       loop: "{{ inventory_files.files }}"
-      when: instances_to_delete is defined and instances_to_delete | length > 0
+      when: all_instances_info is defined and all_instances_info.results is defined
 
-    - name: Clean up instance details files
+    - name: Clean up instance details files (from AWS results)
       file:
-        path: "./instance-{{ item.instance_id }}-details.txt"
+        path: "./instance-{{ item.1.instance_id }}-details.txt"
         state: absent
-      loop: "{{ instances_to_delete }}"
-      when: instances_to_delete is defined and instances_to_delete | length > 0
+      loop: "{{ all_instances_info.results | subelements('instances') }}"
+      when: all_instances_info is defined and all_instances_info.results is defined
+      ignore_errors: yes
+
+    - name: Clean up instance details files (fallback - clean all found details files)
+      file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ details_files.files }}"
+      when: details_files.files is defined and details_files.files | length > 0
       ignore_errors: yes
 
     - name: Clean up kubeconfig files
@@ -125,7 +181,7 @@
         paths: "."
         patterns: "kubeconfig-*"
       register: kubeconfig_files
-      when: instances_to_delete is defined and instances_to_delete | length > 0
+      when: all_instances_info is defined and all_instances_info.results is defined
 
     - name: Remove kubeconfig files
       file:
@@ -133,18 +189,30 @@
         state: absent
       loop: "{{ kubeconfig_files.files }}"
       when: 
-        - instances_to_delete is defined and instances_to_delete | length > 0
+        - all_instances_info is defined and all_instances_info.results is defined
         - kubeconfig_files.files is defined
       ignore_errors: yes
+
+    - name: Calculate total instances
+      set_fact:
+        total_instances: >-
+          {{
+            all_instances_info.results | map(attribute='instances') | map('length') | sum
+            if all_instances_info is defined and all_instances_info.results is defined
+            else 0
+          }}
 
     - name: Final cleanup summary
       debug:
         msg: |
           Cleanup completed!
-          {% if instances_to_delete is defined and instances_to_delete | length > 0 %}
-          Terminated {{ instances_to_delete | length }} instance(s):
-          {% for instance in instances_to_delete %}
+          {% if all_instances_info is defined and all_instances_info.results is defined %}
+          Terminated {{ total_instances }} instance(s) across {{ all_instances_info.results | length }} region(s):
+          {% for region_result in all_instances_info.results %}
+          Region {{ region_result.item.key }}:
+          {% for instance in region_result.instances %}
           - {{ instance.instance_id }} ({{ instance.tags.Name | default('N/A') }})
+          {% endfor %}
           {% endfor %}
           
           Cleaned up {{ inventory_files.files | length }} inventory file(s) and related files.

--- a/kubernetes-single-node.yaml
+++ b/kubernetes-single-node.yaml
@@ -249,7 +249,7 @@
       
     - name: Create .kube directory for user
       file:
-        path: "{{ ansible_env.HOME }}/.kube"
+        path: "/home/{{ ansible_user }}/.kube"
         state: directory
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
@@ -267,7 +267,7 @@
     - name: Copy admin.conf to user's kube config
       copy:
         src: /etc/kubernetes/admin.conf
-        dest: "{{ ansible_env.HOME }}/.kube/config"
+        dest: "/home/{{ ansible_user }}/.kube/config"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0644'
@@ -282,6 +282,15 @@
         mode: '0644'
         remote_src: yes
       when: ansible_env.USER != ansible_user or ansible_user is undefined
+
+    - name: Add kubectl alias to user's .bashrc
+      lineinfile:
+        path: "/home/{{ ansible_user }}/.bashrc"
+        line: "alias k='kubectl'"
+        create: yes
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0644'
 
     - name: Wait for Kubernetes nodes to be ready
       shell: kubectl get nodes --request-timeout=10s

--- a/launch-instance.yaml
+++ b/launch-instance.yaml
@@ -1,14 +1,27 @@
 ---
-- name: Launch AWS GPU instance in US East 2
+- name: Launch AWS GPU instance
   hosts: localhost
   connection: local
   gather_facts: true
   vars:
-    aws_region: us-east-2
-    instance_type:  g6.4xlarge # 1 V100 GPU or g6.4xlarge 1 L4 GPU
-    ami_id: ami-00f71ac70c2d6344d  # Ubuntu 22.04 with NVIDIA GPU driver
-    key_pair: router-team-us-east2
-    security_group_id: sg-0704e6bcaa5e655b1  # k8s security group
+    instance_type: g6.4xlarge # 1 V100 GPU or g6.4xlarge 1 L4 GPU
+    
+    # Regions to try in order (us-east-1 first, then us-east-2)
+    regions_to_try:
+      - us-east-1
+      - us-east-2
+    
+    # Common configuration (same across regions where possible)
+    key_pair: router-team-us-east2  # Use common key pair name (must be created in each region)
+    
+    # Region-specific configurations (only what must be different)
+    region_configs:
+      us-east-1:
+        ami_id: ami-0e2c8caa4b6378d8c  # Ubuntu 22.04 with NVIDIA GPU driver
+        security_group_id: sg-076807475732436dd  # Copy of k8s security group from us-east-2
+      us-east-2:
+        ami_id: ami-00f71ac70c2d6344d  # Ubuntu 22.04 with NVIDIA GPU driver
+        security_group_id: sg-0704e6bcaa5e655b1  # k8s security group
     root_volume_size: 500  # GB
     instance_name: "{{ ansible_hostname }}-{{ ansible_date_time.epoch }}"
     
@@ -21,16 +34,20 @@
         state: present
       delegate_to: localhost
 
-    - name: Launch EC2 instance
+    - name: Initialize launch tracking
+      set_fact:
+        launch_successful: false
+
+    - name: Try launching instance in first preferred region
       amazon.aws.ec2_instance:
-        region: "{{ aws_region }}"
-        availability_zone: "{{ aws_region }}b"
+        region: "{{ regions_to_try[0] }}"
+        availability_zone: "{{ regions_to_try[0] }}b"
         name: "{{ instance_name }}"
-        image_id: "{{ ami_id }}"
+        image_id: "{{ region_configs[regions_to_try[0]].ami_id }}"
         instance_type: "{{ instance_type }}"
         key_name: "{{ key_pair }}"
         security_groups:
-          - "{{ security_group_id }}"
+          - "{{ region_configs[regions_to_try[0]].security_group_id }}"
         volumes:
           - device_name: /dev/sda1
             ebs:
@@ -45,10 +62,100 @@
           Name: "{{ instance_name }}"
           Environment: production
           InstanceType: "{{ instance_type }}"
-          AMI: "{{ ami_id }}"
+          AMI: "{{ region_configs[regions_to_try[0]].ami_id }}"
           CreatedBy: ansible
           CreatedAt: "{{ ansible_date_time.iso8601 }}"
-      register: ec2_instance
+          Region: "{{ regions_to_try[0] }}"
+      register: launch_attempt_0
+      ignore_errors: yes
+
+    - name: Set success if first region succeeded
+      set_fact:
+        launch_successful: true
+        ec2_instance: "{{ launch_attempt_0 }}"
+        aws_region: "{{ regions_to_try[0] }}"
+        ami_id: "{{ region_configs[regions_to_try[0]].ami_id }}"
+      when: 
+        - not launch_attempt_0.failed
+        - launch_attempt_0.instances is defined
+        - launch_attempt_0.instances | length > 0
+
+    - name: Try launching instance in second preferred region
+      amazon.aws.ec2_instance:
+        region: "{{ regions_to_try[1] }}"
+        availability_zone: "{{ regions_to_try[1] }}b"
+        name: "{{ instance_name }}"
+        image_id: "{{ region_configs[regions_to_try[1]].ami_id }}"
+        instance_type: "{{ instance_type }}"
+        key_name: "{{ key_pair }}"
+        security_groups:
+          - "{{ region_configs[regions_to_try[1]].security_group_id }}"
+        volumes:
+          - device_name: /dev/sda1
+            ebs:
+              volume_type: gp3
+              volume_size: "{{ root_volume_size }}"
+              delete_on_termination: true
+              encrypted: true
+        state: running
+        wait: true
+        wait_timeout: 600
+        tags:
+          Name: "{{ instance_name }}"
+          Environment: production
+          InstanceType: "{{ instance_type }}"
+          AMI: "{{ region_configs[regions_to_try[1]].ami_id }}"
+          CreatedBy: ansible
+          CreatedAt: "{{ ansible_date_time.iso8601 }}"
+          Region: "{{ regions_to_try[1] }}"
+      register: launch_attempt_1
+      ignore_errors: yes
+      when: 
+        - not (launch_successful | default(false))
+        - regions_to_try | length > 1
+
+    - name: Set success if second region succeeded  
+      set_fact:
+        launch_successful: true
+        ec2_instance: "{{ launch_attempt_1 }}"
+        aws_region: "{{ regions_to_try[1] }}"
+        ami_id: "{{ region_configs[regions_to_try[1]].ami_id }}"
+      when: 
+        - not (launch_successful | default(false))
+        - regions_to_try | length > 1
+        - not launch_attempt_1.failed
+        - launch_attempt_1.instances is defined
+        - launch_attempt_1.instances | length > 0
+
+    - name: Display successful launch information
+      debug:
+        msg:
+          - "Successfully launched instance in region: {{ aws_region }}"
+          - "Instance ID: {{ ec2_instance.instances[0].instance_id }}"
+          - "AMI ID: {{ ami_id }}"
+          - "Key pair: {{ key_pair }}"
+          - "Security group: {{ region_configs[aws_region].security_group_id }}"
+      when: launch_successful
+
+    - name: Display failed regions
+      debug:
+        msg: "Failed to launch in region: {{ regions_to_try[0] }} - {{ launch_attempt_0.msg | default('Unknown error') }}"
+      when: 
+        - launch_attempt_0 is defined
+        - launch_attempt_0.failed
+
+    - name: Display failed second region
+      debug:
+        msg: "Failed to launch in region: {{ regions_to_try[1] }} - {{ launch_attempt_1.msg | default('Unknown error') }}"
+      when: 
+        - regions_to_try | length > 1
+        - launch_attempt_1 is defined
+        - launch_attempt_1.failed | default(false)
+
+    - name: Fail if all regions failed
+      fail:
+        msg: "Failed to launch instance in all attempted regions: {{ regions_to_try | join(', ') }}"
+      when: not (launch_successful | default(false))
 
     - name: Display instance information
       debug:
@@ -93,7 +200,7 @@
           Public IP: {{ ec2_instance.instances[0].public_ip_address | default('N/A') }}
           Private IP: {{ ec2_instance.instances[0].private_ip_address }}
           Key Pair: {{ key_pair }}
-          Security Group: {{ security_group_id }}
+          Security Group: {{ region_configs[aws_region].security_group_id }}
           Root Volume Size: {{ root_volume_size }}GB
           Launch Time: {{ ec2_instance.instances[0].launch_time }}
           
@@ -160,3 +267,4 @@
     - name: Display GPU information
       debug:
         msg: "GPU Information: {{ gpu_check.stdout if gpu_check.rc == 0 else 'No NVIDIA GPU detected' }}" 
+

--- a/llm-d-test.yaml
+++ b/llm-d-test.yaml
@@ -11,6 +11,74 @@
       set_fact:
         test_id: "{{ 999999 | random }}"
 
+    - name: Wait for decode pod to be ready
+      shell: >-
+        echo "Checking for decode pod existence and readiness..." &&
+        timeout=300 &&
+        elapsed=0 &&
+        DECODE_POD="" &&
+        POD_STATUS="" &&
+        while [ $elapsed -lt $timeout ]; do
+          DECODE_POD=$(kubectl get pods -n "{{ llm_d_namespace }}" -l app.kubernetes.io/name=qwen-qwen3-0-6b-decode --no-headers 2>/dev/null | head -1 | cut -d' ' -f1 || echo "") &&
+          if [ -z "$DECODE_POD" ]; then
+            echo "No decode pod found by label, checking for any decode pod..." &&
+            DECODE_POD=$(kubectl get pods -n "{{ llm_d_namespace }}" --no-headers 2>/dev/null | grep decode | head -1 | cut -d' ' -f1 || echo "") ;
+          fi &&
+          if [ -n "$DECODE_POD" ]; then
+            POD_STATUS=$(kubectl get pod -n "{{ llm_d_namespace }}" "$DECODE_POD" --no-headers 2>/dev/null | tr -s ' ' | cut -d' ' -f3 || echo "Unknown") &&
+            echo "[STATUS] Pod Status Check: $DECODE_POD = $POD_STATUS" &&
+            if [ "$POD_STATUS" = "Running" ]; then
+              echo "[SUCCESS] Decode pod $DECODE_POD is running, moving to readiness check..." &&
+              break ;
+            else
+              echo "[WAITING] Pod not ready yet: $DECODE_POD status is $POD_STATUS (need Running)" ;
+            fi ;
+          else
+            echo "[NOT FOUND] Decode pod not found yet, waiting..." ;
+          fi &&
+          sleep 10 &&
+          elapsed=$((elapsed + 10)) ;
+        done &&
+        if [ -z "$DECODE_POD" ]; then
+          echo "Error: No decode pod found after timeout" &&
+          kubectl get pods -n "{{ llm_d_namespace }}" --no-headers | head -5 &&
+          exit 1 ;
+        fi &&
+        if [ "$POD_STATUS" != "Running" ]; then
+          echo "Error: Decode pod $DECODE_POD not running (status: $POD_STATUS)" &&
+          kubectl describe pod -n "{{ llm_d_namespace }}" "$DECODE_POD" | tail -10 &&
+          exit 1 ;
+        fi &&
+        echo "Decode pod $DECODE_POD is running. Now waiting for it to be ready..." &&
+        readiness_timeout=300 &&
+        elapsed=0 &&
+        while [ $elapsed -lt $readiness_timeout ]; do
+          echo "Checking logs for readiness indicator in pod $DECODE_POD..." &&
+          echo "=== Last 5 lines of decode pod logs ===" &&
+          kubectl logs -n "{{ llm_d_namespace }}" "$DECODE_POD" --tail=5 2>/dev/null || echo "Could not get logs" &&
+          echo "=======================================" &&
+          if [ "$(kubectl logs -n "{{ llm_d_namespace }}" "$DECODE_POD" 2>/dev/null | grep -c 'GET /metrics HTTP/1.1.*200 OK')" -ge 3 ]; then
+            echo "[SUCCESS] Found readiness indicator! Decode pod $DECODE_POD is ready!" &&
+            exit 0 ;
+          fi &&
+          echo "[WAITING] Readiness indicator not found yet. Waiting..." &&
+          sleep 10 &&
+          elapsed=$((elapsed + 10)) ;
+        done &&
+        echo "Timeout waiting for decode pod to be ready" &&
+        echo "Recent logs from decode pod:" &&
+        kubectl logs -n "{{ llm_d_namespace }}" "$DECODE_POD" --tail=20 2>/dev/null || echo "Could not get logs" &&
+        exit 1
+      register: decode_readiness
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+      failed_when: decode_readiness.rc != 0
+
+    - name: Display decode pod readiness check output
+      debug:
+        msg: "{{ decode_readiness.stdout_lines }}"
+      when: decode_readiness.stdout_lines is defined
+
     - name: Get gateway information
       shell: |
         kubectl get gateway -n {{ llm_d_namespace }} -o jsonpath='{.items[0].status.addresses[0].value}' 2>/dev/null || \

--- a/test-llm-d.sh
+++ b/test-llm-d.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "=== Testing LLM-D Deployment ==="
+
+# Find the most recent inventory file
+INVENTORY_FILE=$(ls -rt gpu-inventory-*.ini 2>/dev/null | tail -1)
+
+if [ -z "$INVENTORY_FILE" ]; then
+    echo "Error: No inventory file found (gpu-inventory-*.ini)"
+    echo "Make sure you have deployed the cluster first."
+    exit 1
+fi
+
+echo "Using inventory file: $INVENTORY_FILE"
+echo "Running LLM-D tests..."
+
+ansible-playbook -i "$INVENTORY_FILE" llm-d-test.yaml
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ All tests passed!"
+else
+    echo ""
+    echo "❌ Some tests failed."
+    echo "This may be due to pods not being fully ready yet."
+    echo "Wait a few minutes and try running this script again."
+fi 


### PR DESCRIPTION
- Currently just supports us-east 1 and 2. Structure exists to support other regions, but we'd need to create a matching key pair and security group in each new region and update the script before it will work.
- Also added logic to wait for the debug code to be ready before starting the test.  It currently waits for up to 5 minutes for the decode pod to transition into the "Running" state, and then checks the logs for up to another 5 minutes for the decode pod to print a log message that indicates it's ready.  During my testing, I've seen that it takes about 3.5 minutes for the pod to transition to the "Running" state, and about another 2 minutes for the model to become ready.
- Added a script called test-llm-d.sh that can be called execute just the test in case you want to run it again later.